### PR TITLE
Fix FOMODs not installing properly.

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -96,7 +96,6 @@ export const MOD_TYPE_BP_PAK = `${GAME_ID}-blueprint-modtype`;
 export const MOD_TYPE_UNREAL_PAK_TOOL = `${GAME_ID}-unreal-pak-tool-modtype`;
 export const MOD_TYPE_DATAPATH = `${GAME_ID}-data-folder`;
 export const MOD_TYPE_BINARIES = `${GAME_ID}-binaries-modtype`;
-export const MOD_TYPE_ROOT = `${GAME_ID}-root-modtype`;
 
 export const UE_PAK_TOOL_FILENAME = 'UnrealPakTool.zip';
 

--- a/src/common.ts
+++ b/src/common.ts
@@ -89,6 +89,7 @@ export const TOP_LEVEL_DIRECTORIES = [
 
 export const TOOL_ID_OBSE64 = 'tool-obse64';
 
+export const MOD_TYPE_ROOT = `${GAME_ID}-root-mod`;
 export const MOD_TYPE_INI_TWEAKS = `${GAME_ID}-ini-tweaks`;
 export const MOD_TYPE_PAK = `${GAME_ID}-pak-modtype`;
 export const MOD_TYPE_LUA = `${GAME_ID}-lua-modtype`;

--- a/src/common.ts
+++ b/src/common.ts
@@ -96,6 +96,7 @@ export const MOD_TYPE_BP_PAK = `${GAME_ID}-blueprint-modtype`;
 export const MOD_TYPE_UNREAL_PAK_TOOL = `${GAME_ID}-unreal-pak-tool-modtype`;
 export const MOD_TYPE_DATAPATH = `${GAME_ID}-data-folder`;
 export const MOD_TYPE_BINARIES = `${GAME_ID}-binaries-modtype`;
+export const MOD_TYPE_ROOT = `${GAME_ID}-root-modtype`;
 
 export const UE_PAK_TOOL_FILENAME = 'UnrealPakTool.zip';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -156,6 +156,11 @@ function main(context: types.IExtensionContext) {
 
   context.registerInstaller(`${GAME_ID}-lua-installer`, 30, testLuaMod as any, installLuaMod(context.api) as any);
 
+  // BP_PAK modType must have a lower priority than regular PAKs
+  //  this ensures that we get a chance to detect the LogicMods folder
+    //  structure before we just deploy it to ~mods
+
+
   context.registerModType(
     MOD_TYPE_ROOT,
     5,
@@ -164,10 +169,6 @@ function main(context: types.IExtensionContext) {
     (instructions: types.IInstruction[]) => testRootPath(context.api, instructions) as any,
     { deploymentEssential: true, name: 'Root Mod' }
   );
-
-  // BP_PAK modType must have a lower priority than regular PAKs
-  //  this ensures that we get a chance to detect the LogicMods folder
-  //  structure before we just deploy it to ~mods
 
   context.registerModType(
     MOD_TYPE_BP_PAK,

--- a/src/index.ts
+++ b/src/index.ts
@@ -147,13 +147,13 @@ function main(context: types.IExtensionContext) {
     }, () => isGameActive(context.api)() && lootSortingAllowed(context.api),
   )
 
-  context.registerInstaller(`${GAME_ID}-root-mod`, 5, testRootMod as any, installRootMod(context.api) as any);
 
   context.registerInstaller(`${GAME_ID}-ue4ss`, 10, testUE4SSInjector as any, installUE4SSInjector(context.api) as any);
 
   // Runs after UE4SS to ensure that we don't accidentally install UE4SS as a root mod.
   //  But must run before lua and pak installers to ensure we don't install a root mod
   //  as a lua mod.
+  context.registerInstaller(`${GAME_ID}-root-mod`, 15, testRootMod as any, installRootMod(context.api) as any);
 
   context.registerInstaller(`${GAME_ID}-lua-installer`, 30, testLuaMod as any, installLuaMod(context.api) as any);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -156,11 +156,6 @@ function main(context: types.IExtensionContext) {
 
   context.registerInstaller(`${GAME_ID}-lua-installer`, 30, testLuaMod as any, installLuaMod(context.api) as any);
 
-  // BP_PAK modType must have a lower priority than regular PAKs
-  //  this ensures that we get a chance to detect the LogicMods folder
-    //  structure before we just deploy it to ~mods
-
-
   context.registerModType(
     MOD_TYPE_ROOT,
     5,
@@ -169,6 +164,10 @@ function main(context: types.IExtensionContext) {
     (instructions: types.IInstruction[]) => testRootPath(context.api, instructions) as any,
     { deploymentEssential: true, name: 'Root Mod' }
   );
+
+  // BP_PAK modType must have a lower priority than regular PAKs
+  //  this ensures that we get a chance to detect the LogicMods folder
+  //  structure before we just deploy it to ~mods
 
   context.registerModType(
     MOD_TYPE_BP_PAK,

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ import {
   BPPAK_MODSFOLDER_PATH, IGNORE_DEPLOY,
   MOD_TYPE_DATAPATH, NATIVE_PLUGINS, DATA_PATH,
   MOD_TYPE_BINARIES, OBSE64_EXECUTABLE, TOOL_ID_OBSE64,
-  MOD_TYPE_INI_TWEAKS,
+  MOD_TYPE_ROOT, MOD_TYPE_INI_TWEAKS,
 } from './common';
 
 import {
@@ -24,7 +24,7 @@ import { sessionReducer, settingsReducer } from './reducers';
 import { getStopPatterns } from './stopPatterns';
 
 import {
-  getBPPakPath, getPakPath, testBPPakPath, testPakPath,
+  getRootPath, testRootPath, getBPPakPath, getPakPath, testBPPakPath, testPakPath,
   getLUAPath, testLUAPath, getDataPath, testDataPath,
   getBinariesPath, testBinariesPath,
 } from './modTypes';
@@ -158,7 +158,18 @@ function main(context: types.IExtensionContext) {
 
   // BP_PAK modType must have a lower priority than regular PAKs
   //  this ensures that we get a chance to detect the LogicMods folder
-  //  structure before we just deploy it to ~mods
+    //  structure before we just deploy it to ~mods
+
+
+  context.registerModType(
+    MOD_TYPE_ROOT,
+    5,
+    isGameActive(context.api),
+    (game: types.IGame) => getRootPath(context.api, game),
+    (instructions: types.IInstruction[]) => testRootPath(context.api, instructions) as any,
+    { deploymentEssential: true, name: 'Root Mod' }
+  );
+
   context.registerModType(
     MOD_TYPE_BP_PAK,
     5,

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ import {
   BPPAK_MODSFOLDER_PATH, IGNORE_DEPLOY,
   MOD_TYPE_DATAPATH, NATIVE_PLUGINS, DATA_PATH,
   MOD_TYPE_BINARIES, OBSE64_EXECUTABLE, TOOL_ID_OBSE64,
-  MOD_TYPE_ROOT, MOD_TYPE_INI_TWEAKS,
+  MOD_TYPE_INI_TWEAKS,
 } from './common';
 
 import {
@@ -24,7 +24,7 @@ import { sessionReducer, settingsReducer } from './reducers';
 import { getStopPatterns } from './stopPatterns';
 
 import {
-  getRootPath, testRootPath, getBPPakPath, getPakPath, testBPPakPath, testPakPath,
+  getBPPakPath, getPakPath, testBPPakPath, testPakPath,
   getLUAPath, testLUAPath, getDataPath, testDataPath,
   getBinariesPath, testBinariesPath,
 } from './modTypes';
@@ -158,18 +158,7 @@ function main(context: types.IExtensionContext) {
 
   // BP_PAK modType must have a lower priority than regular PAKs
   //  this ensures that we get a chance to detect the LogicMods folder
-    //  structure before we just deploy it to ~mods
-
-
-  context.registerModType(
-    MOD_TYPE_ROOT,
-    5,
-    isGameActive(context.api),
-    (game: types.IGame) => getRootPath(context.api, game),
-    (instructions: types.IInstruction[]) => testRootPath(context.api, instructions) as any,
-    { deploymentEssential: true, name: 'Root Mod' }
-  );
-
+  //  structure before we just deploy it to ~mods
   context.registerModType(
     MOD_TYPE_BP_PAK,
     5,

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ import {
   BPPAK_MODSFOLDER_PATH, IGNORE_DEPLOY,
   MOD_TYPE_DATAPATH, NATIVE_PLUGINS, DATA_PATH,
   MOD_TYPE_BINARIES, OBSE64_EXECUTABLE, TOOL_ID_OBSE64,
-  MOD_TYPE_INI_TWEAKS,
+  MOD_TYPE_ROOT, MOD_TYPE_INI_TWEAKS,
 } from './common';
 
 import {
@@ -24,7 +24,7 @@ import { sessionReducer, settingsReducer } from './reducers';
 import { getStopPatterns } from './stopPatterns';
 
 import {
-  getBPPakPath, getPakPath, testBPPakPath, testPakPath,
+  getRootPath, testRootPath, getBPPakPath, getPakPath, testBPPakPath, testPakPath,
   getLUAPath, testLUAPath, getDataPath, testDataPath,
   getBinariesPath, testBinariesPath,
 } from './modTypes';
@@ -147,18 +147,29 @@ function main(context: types.IExtensionContext) {
     }, () => isGameActive(context.api)() && lootSortingAllowed(context.api),
   )
 
+  context.registerInstaller(`${GAME_ID}-root-mod`, 5, testRootMod as any, installRootMod(context.api) as any);
+
   context.registerInstaller(`${GAME_ID}-ue4ss`, 10, testUE4SSInjector as any, installUE4SSInjector(context.api) as any);
 
   // Runs after UE4SS to ensure that we don't accidentally install UE4SS as a root mod.
   //  But must run before lua and pak installers to ensure we don't install a root mod
   //  as a lua mod.
-  context.registerInstaller(`${GAME_ID}-root-mod`, 15, testRootMod as any, installRootMod(context.api) as any);
 
   context.registerInstaller(`${GAME_ID}-lua-installer`, 30, testLuaMod as any, installLuaMod(context.api) as any);
+
+  context.registerModType(
+    MOD_TYPE_ROOT,
+    5,
+    isGameActive(context.api),
+    (game: types.IGame) => getRootPath(context.api, game),
+    (instructions: types.IInstruction[]) => testRootPath(context.api, instructions) as any,
+    { deploymentEssential: true, name: 'Root Mod' }
+  );
 
   // BP_PAK modType must have a lower priority than regular PAKs
   //  this ensures that we get a chance to detect the LogicMods folder
   //  structure before we just deploy it to ~mods
+
   context.registerModType(
     MOD_TYPE_BP_PAK,
     5,

--- a/src/modTypes.ts
+++ b/src/modTypes.ts
@@ -15,29 +15,6 @@ import { resolveUE4SSPath, findInstallFolderByFile } from './util';
 const hasModTypeInstruction = (instructions: types.IInstruction[]) => instructions.find(instr => instr.type === 'setmodtype');
 //#endregion
 
-export function getRootPath(api: types.IExtensionApi, game: types.IGame) {
-  const discovery = selectors.discoveryByGame(api.getState(), game.id);
-  if (!discovery || !discovery.path) {
-    return '.';
-  }
-  return discovery.path;
-}
-
-export async function testRootPath(
-    api: types.IExtensionApi,
-    instructions: types.IInstruction[]
-): Promise<boolean> {
-    // Skip if another installer has already set modtype
-    if (hasModTypeInstruction(instructions)) {
-        return false;
-    }
-    // Detect FOMOD package by ModuleConfig.xml in copy list
-    return instructions.some(inst =>
-        inst.type === 'copy' &&
-        path.basename(inst.source as string).toLowerCase() === 'moduleconfig.xml'
-    );
-}
-
 //#region MOD_TYPE_PAK
 export function getPakPath(api: types.IExtensionApi, game: types.IGame) {
   const discovery = selectors.discoveryByGame(api.getState(), game.id);

--- a/src/modTypes.ts
+++ b/src/modTypes.ts
@@ -15,6 +15,29 @@ import { resolveUE4SSPath, findInstallFolderByFile } from './util';
 const hasModTypeInstruction = (instructions: types.IInstruction[]) => instructions.find(instr => instr.type === 'setmodtype');
 //#endregion
 
+export function getRootPath(api: types.IExtensionApi, game: types.IGame) {
+  const discovery = selectors.discoveryByGame(api.getState(), game.id);
+  if (!discovery || !discovery.path) {
+    return '.';
+  }
+  return discovery.path;
+}
+
+export async function testRootPath(
+    api: types.IExtensionApi,
+    instructions: types.IInstruction[]
+): Promise<boolean> {
+    // Skip if another installer has already set modtype
+    if (hasModTypeInstruction(instructions)) {
+        return false;
+    }
+    // Detect FOMOD package by ModuleConfig.xml in copy list
+    return instructions.some(inst =>
+        inst.type === 'copy' &&
+        path.basename(inst.source as string).toLowerCase() === 'moduleconfig.xml'
+    );
+}
+
 //#region MOD_TYPE_PAK
 export function getPakPath(api: types.IExtensionApi, game: types.IGame) {
   const discovery = selectors.discoveryByGame(api.getState(), game.id);

--- a/src/modTypes.ts
+++ b/src/modTypes.ts
@@ -33,17 +33,17 @@ export function getRootPath(
 export async function testRootPath(
     api: types.IExtensionApi,
     instructions: types.IInstruction[],
-): Promise<types.ISupportedResult> {
+): Promise<boolean> {
     // If another installer set the mod type, skip
     if (instructions.find(i => i.type === 'setmodtype')) {
-        return { supported: false, requiredFiles: [] };
+        return false;
     }
     // Detect a FOMOD package by the XML file presence
     const hasModuleConfig = instructions.some(inst =>
         inst.type === 'copy' &&
         path.basename(inst.source as string).toLowerCase() === 'moduleconfig.xml'
     );
-    return { supported: hasModuleConfig, requiredFiles: [] };
+    return hasModuleConfig;
 }
 
 //#region MOD_TYPE_PAK


### PR DESCRIPTION
This file previously would not install properly. 
[FarmScythe.zip](https://github.com/user-attachments/files/20683417/FarmScythe.zip)

with the files being written to here:
`OblivionRemastered\Content\Paks\~Mods\OblivionRemastered\Content\...`

This PR fixes that. Could probably change testRootPath to something like testFomodPath to be more accurate. But I digress.

~PR doesn't actually work~ it works now ~but~ the index.js that ~does~ also works is here:
[index.zip](https://github.com/user-attachments/files/20683854/index.zip)

I was just editing the index.js to try and get it to work, after I found out about the repo I tried to redo what I did compiling the file and comparing the results. 

EDIT: Fixed for real this time, the source should produce pretty much what is in the index.js in the .zip. 
Before the compiled source would install that FarmScythe.zip but only because it had a vortex_override_instructions.json with this in it: 
`[{ "type": "setmodtype", "value": "fomod" }]`
so it only half worked. Now it works if it doesn't have that.